### PR TITLE
Add command to reload .bashrc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,11 @@ rpg () {
 }
 ```
 
+Then use this command to reload `.bashrc` without logging out and back in again:
+```sh
+source ~/.bashrc
+```
+
 ## Usage
 
 The first time you run the program, a new hero is created at the user's home directory.


### PR DESCRIPTION
Hi, after editing `.bashrc`, I suggest to use `source ~/.bashrc` to reload `.bashrc`, otherwise will need to log out and log back. 

I am not sure whether the description is good for you or not, so feel free to edit the description if you would like to accept this PR, thanks!