### PR TITLE
Improve cd replacement docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,9 @@ Once the binary is installed with one of the methods described above, it can be 
 so the working directory is updated to track to the hero's progress. You can set that up by adding something like this to your `.bashrc`:
 
 ```sh
-rpg () {
+cd () {
    rpg-cli "$@"
-   cd "$(rpg-cli --pwd)"
+   builtin cd "$(rpg-cli --pwd)"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -32,13 +32,23 @@ Once the binary is installed with one of the methods described above, it can be 
 so the working directory is updated to track to the hero's progress. You can set that up by adding something like this to your `.bashrc`:
 
 ```sh
+rpg () {
+   rpg-cli "$@"
+   cd "$(rpg-cli --pwd)"
+}
+```
+
+This assumes `rpg-cli` is in your path, update with the specific location if not. You can `source ~/.bashrc` to apply the change without opening a new shell.
+
+Or, if you want to go all the way and *really* use it in place of `cd`:
+
+```sh
 cd () {
    rpg-cli "$@"
    builtin cd "$(rpg-cli --pwd)"
 }
 ```
 
-This assumes `rpg-cli` is in your path, update with the specific location if not. You can `source ~/.bashrc` to apply the change without opening a new shell.
 
 ### Troubleshooting
 


### PR DESCRIPTION
Actually set the cd command in the example. Use `builtin` to prevent recursion