### PR TITLE
Fix overflow bug

### DIFF
--- a/src/character/class.rs
+++ b/src/character/class.rs
@@ -22,7 +22,7 @@ impl Class {
         start_strength: 10,
         start_speed: 5,
 
-        hp_rate: 0.3,
+        hp_rate: 0.25,
         strength_rate: 0.2,
         speed_rate: 0.1,
     };
@@ -40,7 +40,9 @@ impl Class {
     }
 }
 
+// FIXME this is no longer true, and has become more like an equipment related function
 fn stat_at(stat_rate: f64, stat_start: i32, level: i32) -> i32 {
+    let stat_rate = stat_rate / ((level / 25 + 1 ) as f64);
     let inc_rate = 1.0 + stat_rate;
     (stat_start as f64 * inc_rate.powi(level)) as i32
 }

--- a/src/character/class.rs
+++ b/src/character/class.rs
@@ -92,7 +92,7 @@ const BASE: Class = Class {
     start_strength: 10,
     start_speed: 3,
 
-    hp_rate: 0.15,
+    hp_rate: 0.10,
     strength_rate: 0.07,
     speed_rate: 0.07,
 };

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -329,4 +329,31 @@ mod tests {
         assert_eq!(25, hero.max_hp);
         assert_eq!(25, hero.current_hp);
     }
+
+    #[test]
+    fn test_overflow() {
+        let mut hero = new_char();
+
+        while hero.level < 200 {
+            hero.add_experience(hero.xp_for_next());
+            hero.sword = Some(equipment::Sword::new(hero.level));
+            let turns_unarmed = hero.max_hp / hero.strength;
+            let turns_armed = hero.max_hp / hero.attack();
+            println!(
+                "hero[{}] next={} hp={} spd={} str={} att={} turns_u={} turns_a={}",
+                hero.level,
+                hero.xp_for_next(),
+                hero.max_hp,
+                hero.speed,
+                hero.strength,
+                hero.attack(),
+                turns_unarmed,
+                turns_armed
+            );
+
+            assert!(hero.max_hp > 0);
+            assert!(hero.speed > 0);
+            assert!(hero.attack() > 0);
+        }
+    }
 }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -71,13 +71,13 @@ impl Character {
     /// Raise the level and all the character stats.
     fn increase_level(&mut self) {
         self.level += 1;
-        self.strength = random().stat_increase(self.strength, self.class.strength_rate);
-        self.speed = random().stat_increase(self.speed, self.class.speed_rate);
+        self.strength = random().stat_increase(self.level, self.strength, self.class.strength_rate);
+        self.speed = random().stat_increase(self.level, self.speed, self.class.speed_rate);
 
         // the current should increase proportionally but not
         // erase previous damage
         let previous_damage = self.max_hp - self.current_hp;
-        self.max_hp = random().stat_increase(self.max_hp, self.class.hp_rate);
+        self.max_hp = random().stat_increase(self.level, self.max_hp, self.class.hp_rate);
         self.current_hp = self.max_hp - previous_damage;
     }
 
@@ -124,7 +124,7 @@ impl Character {
         (base_xp * (self.level as f64).powf(exp)) as i32
     }
 
-    /// Generate a randomized damage numer based on the attacker strength
+    /// Generate a randomized damage number based on the attacker strength
     /// and the receiver strength.
     pub fn damage(&self, receiver: &Self) -> i32 {
         max(1, self.attack() - receiver.deffense())
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_overflow() {
-        let mut hero = new_char();
+        let mut hero = Character::player();
 
         while hero.level < 200 {
             hero.add_experience(hero.xp_for_next());
@@ -355,5 +355,6 @@ mod tests {
             assert!(hero.speed > 0);
             assert!(hero.attack() > 0);
         }
+        // assert!(false);
     }
 }

--- a/src/game/battle.rs
+++ b/src/game/battle.rs
@@ -56,7 +56,11 @@ fn enemy_attack(game: &mut Game, enemy: &Character, random: &dyn Randomizer) {
 
 /// Inflict damage from attacker to receiver, return the inflicted
 /// damage and the experience that will be gain if the battle is won
-fn attack(attacker: &Character, receiver: &mut Character, random: &dyn Randomizer) -> (Attack, i32) {
+fn attack(
+    attacker: &Character,
+    receiver: &mut Character,
+    random: &dyn Randomizer,
+) -> (Attack, i32) {
     if random.is_miss(attacker.speed, receiver.speed) {
         (Attack::Miss, 0)
     } else {

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -159,7 +159,7 @@ impl Game {
     }
 
     fn bribe(&mut self, enemy: &Character) -> bool {
-        let bribe_cost = gold_gained(enemy.level) / 2;
+        let bribe_cost = gold_gained(self.player.level, enemy.level) / 2;
 
         if self.gold >= bribe_cost && random().bribe_succeeds() {
             self.gold -= bribe_cost;
@@ -181,7 +181,7 @@ impl Game {
 
     fn battle(&mut self, enemy: &mut Character) -> Result<(), Error> {
         if let Ok(xp) = battle::run(self, enemy, &random()) {
-            let gold = gold_gained(enemy.level);
+            let gold = gold_gained(self.player.level, enemy.level);
             self.gold += gold;
             let level_up = self.player.add_experience(xp);
 
@@ -216,8 +216,9 @@ fn enemy_level(player_level: i32, distance_from_home: i32) -> i32 {
     std::cmp::max(player_level / 2 + distance_from_home - 1, 1)
 }
 
-fn gold_gained(enemy_level: i32) -> i32 {
-    random().gold_gained(enemy_level * 100)
+fn gold_gained(player_level: i32, enemy_level: i32) -> i32 {
+   let level =  std::cmp::max(2, enemy_level - player_level);
+    random().gold_gained(level * 100)
 }
 
 #[cfg(test)]

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -292,22 +292,22 @@ mod tests {
         // level's equipment, should be able to beat any enemy of its same level
         // without relying in randomness.
         let (wins, lost_to) = run_battles_at(1, 1, times);
-        assert_wins(times, wins, 0.75, &lost_to);
+        assert_wins(times, wins, 0.7, &lost_to);
 
         let (wins, lost_to) = run_battles_at(1, 3, times);
         assert_wins(times, wins, 0.3, &lost_to);
 
         let (wins, lost_to) = run_battles_at(5, 5, times);
-        assert_wins(times, wins, 0.75, &lost_to);
+        assert_wins(times, wins, 0.7, &lost_to);
 
         let (wins, lost_to) = run_battles_at(10, 5, times);
-        assert_wins(times, wins, 0.75, &lost_to);
+        assert_wins(times, wins, 0.7, &lost_to);
 
         let (wins, lost_to) = run_battles_at(10, 10, times);
         assert_wins(times, wins, 0.4, &lost_to);
 
         let (wins, lost_to) = run_battles_at(15, 13, times);
-        assert_wins(times, wins, 0.75, &lost_to);
+        assert_wins(times, wins, 0.7, &lost_to);
 
         let (wins, lost_to) = run_battles_at(15, 15, times);
         assert_wins(times, wins, 0.5, &lost_to);

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -217,7 +217,7 @@ fn enemy_level(player_level: i32, distance_from_home: i32) -> i32 {
 }
 
 fn gold_gained(player_level: i32, enemy_level: i32) -> i32 {
-   let level =  std::cmp::max(2, enemy_level - player_level);
+    let level =  std::cmp::max(1, enemy_level - player_level);
     random().gold_gained(level * 100)
 }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -222,8 +222,8 @@ fn gold_gained(enemy_level: i32) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use item::equipment::Equipment;
     use crate::location::Distance;
+    use item::equipment::Equipment;
 
     use super::*;
     use crate::item;
@@ -334,12 +334,24 @@ mod tests {
     }
 
     fn assert_wins(total: i32, wins: i32, expected_ratio: f64, lost_to: &Vec<String>) {
-        assert!(wins as f64 >= total as f64 * expected_ratio , "won {} out of {}. Lost to {:?}", wins, total, lost_to);
+        assert!(
+            wins as f64 >= total as f64 * expected_ratio,
+            "won {} out of {}. Lost to {:?}",
+            wins,
+            total,
+            lost_to
+        );
     }
 
     fn assert_loses(total: i32, wins: i32, expected_ratio: f64) {
         let expected = (total as f64) * (1.0 - expected_ratio);
-        assert!((wins as f64) <= expected, "won {} out of {} expected at most {}", wins, total, expected);
+        assert!(
+            (wins as f64) <= expected,
+            "won {} out of {} expected at most {}",
+            wins,
+            total,
+            expected
+        );
     }
 
     fn run_battles_at(player_level: i32, distance: i32, times: i32) -> (i32, Vec<String>) {
@@ -347,7 +359,7 @@ mod tests {
         let mut lost_to = Vec::new();
 
         // we don't want randomization turned off for this test
-        let random = randomizer::DefaultRandomizer{};
+        let random = randomizer::DefaultRandomizer {};
 
         for _ in 0..times {
             let mut game = full_game_at(player_level);
@@ -371,7 +383,7 @@ mod tests {
         let mut game = Game::new();
 
         // get a player of the given level
-        for _ in 0..level-1 {
+        for _ in 0..level - 1 {
             game.player.add_experience(game.player.xp_for_next());
         }
         assert_eq!(level, game.player.level);

--- a/src/randomizer.rs
+++ b/src/randomizer.rs
@@ -25,7 +25,7 @@ pub trait Randomizer {
 
     fn gold_gained(&self, base: i32) -> i32;
 
-    fn stat_increase(&self, current: i32, rate: f64) -> i32;
+    fn stat_increase(&self, level: i32, current: i32, rate: f64) -> i32;
 }
 
 #[cfg(not(test))]
@@ -104,7 +104,9 @@ impl Randomizer for DefaultRandomizer {
         rng.gen_range(min..=max)
     }
 
-    fn stat_increase(&self, current: i32, rate: f64) -> i32 {
+    fn stat_increase(&self, level: i32, current: i32, rate: f64) -> i32 {
+        let rate = rate / ((level / 10 + 1 ) as f64);
+
         // if rate is .3, increase can be in .15-.45
         let current_f = current as f64;
         let min_value = max(1, (current_f * (rate - rate / 2.0)).round() as i32);
@@ -152,7 +154,8 @@ impl Randomizer for TestRandomizer {
         base
     }
 
-    fn stat_increase(&self, current: i32, rate: f64) -> i32 {
+    fn stat_increase(&self, level: i32, current: i32, rate: f64) -> i32 {
+        let rate = rate / ((level / 10 + 1 ) as f64);
         current + (current as f64 * rate).ceil() as i32
     }
 }
@@ -166,27 +169,27 @@ mod tests {
         let rand = DefaultRandomizer {};
 
         // current hp lvl1: increase in .3 +/- .15
-        let value = rand.stat_increase(20, 0.3);
+        let value = rand.stat_increase(1, 20, 0.3);
         assert!((23..=29).contains(&value), "value was {}", value);
 
         // current strength lvl1
-        let value = rand.stat_increase(10, 0.1);
+        let value = rand.stat_increase(1, 10, 0.1);
         assert!((11..=12).contains(&value), "value was {}", value);
 
         // current speed lvl1
-        let value = rand.stat_increase(5, 0.1);
+        let value = rand.stat_increase(1, 5, 0.1);
         assert_eq!(6, value);
 
         // ~ hp lvl2
-        let value = rand.stat_increase(26, 0.3);
+        let value = rand.stat_increase(1, 26, 0.3);
         assert!((30..=38).contains(&value), "value was {}", value);
 
         // ~ hp lvl3
-        let value = rand.stat_increase(34, 0.3);
+        let value = rand.stat_increase(1, 34, 0.3);
         assert!((39..=49).contains(&value), "value was {}", value);
 
         // small numbers
-        let value = rand.stat_increase(3, 0.07);
+        let value = rand.stat_increase(1, 3, 0.07);
         assert_eq!(4, value);
     }
 }


### PR DESCRIPTION
Some attempts to control the stat growth rate that ends up in overflows. It requires some changes in the way stat increases are computed.

This still needs some testing and code cleanup.

Fixes #21