### PR TITLE
Prevent overflow bug at high levels

### DIFF
--- a/src/character/class.rs
+++ b/src/character/class.rs
@@ -22,7 +22,7 @@ impl Class {
         start_strength: 10,
         start_speed: 5,
 
-        hp_rate: 0.3,
+        hp_rate: 0.25,
         strength_rate: 0.2,
         speed_rate: 0.1,
     };
@@ -40,7 +40,9 @@ impl Class {
     }
 }
 
+// FIXME this is no longer true, and has become more like an equipment related function
 fn stat_at(stat_rate: f64, stat_start: i32, level: i32) -> i32 {
+    let stat_rate = stat_rate / ((level / 25 + 1 ) as f64);
     let inc_rate = 1.0 + stat_rate;
     (stat_start as f64 * inc_rate.powi(level)) as i32
 }

--- a/src/character/class.rs
+++ b/src/character/class.rs
@@ -92,7 +92,7 @@ const BASE: Class = Class {
     start_strength: 10,
     start_speed: 3,
 
-    hp_rate: 0.15,
+    hp_rate: 0.10,
     strength_rate: 0.07,
     speed_rate: 0.07,
 };

--- a/src/character/class.rs
+++ b/src/character/class.rs
@@ -1,10 +1,12 @@
 use crate::location;
 use rand::prelude::SliceRandom;
 
+/// A stat represents an attribute of a character, such as strength or speed.
+/// This struct contains a stat starting value and the amount that should be
+/// applied when the level increases.
 #[derive(Debug)]
 pub struct Stat(pub i32, pub i32);
 
-/// FIXME
 impl Stat {
     pub fn base(&self) -> i32 {
         self.0
@@ -19,8 +21,9 @@ impl Stat {
     }
 }
 
-/// Character classes, which will determine the parameters to start and
-/// increase the stats of the character.
+/// Classes are archetypes for characters.
+/// The struct contains a specific stat configuration such that all instances of
+/// the class have a similar combat behavior.
 #[derive(Debug)]
 pub struct Class {
     pub name: &'static str,

--- a/src/character/class.rs
+++ b/src/character/class.rs
@@ -1,50 +1,54 @@
 use crate::location;
 use rand::prelude::SliceRandom;
 
+#[derive(Debug)]
+struct Stat {
+    pub base: i32,
+    // TODO does it make sense to make this a rate, and make those calculations, if it's always going to be fixed?
+    pub inc_rate: f64,
+}
+
+impl Stat {
+    pub fn at(&self, level: i32) -> i32 {
+        self.base + level * self.increase()
+    }
+
+    pub fn increase(&self) -> i32 {
+        (self.base as f64 * self.inc_rate).ceil() as i32
+    }
+}
+
 /// Character classes, which will determine the parameters to start and
 /// increase the stats of the character.
 #[derive(Debug)]
 pub struct Class {
     pub name: &'static str,
-    pub start_hp: i32,
-    pub start_strength: i32,
-    pub start_speed: i32,
 
-    pub hp_rate: f64,
-    pub strength_rate: f64,
-    pub speed_rate: f64,
+    pub hp: Stat,
+    pub strength: Stat,
+    pub speed: Stat,
 }
 
 impl Class {
     pub const HERO: Self = Self {
         name: "hero",
-        start_hp: 25,
-        start_strength: 10,
-        start_speed: 5,
-
-        hp_rate: 0.25,
-        strength_rate: 0.2,
-        speed_rate: 0.1,
+        hp: Stat {
+            base: 25,
+            inc_rate: 0.25,
+        },
+        strength: Stat {
+            base: 10,
+            inc_rate: 0.2,
+        },
+        speed: Stat {
+            base: 5,
+            inc_rate: 0.1,
+        },
     };
-
-    pub fn strength_at(&self, level: i32) -> i32 {
-        stat_at(self.strength_rate, self.start_strength, level)
-    }
-
-    pub fn hp_at(&self, level: i32) -> i32 {
-        stat_at(self.hp_rate, self.start_hp, level)
-    }
 
     pub fn random_enemy(distance: location::Distance) -> &'static Self {
         weighted_choice(distance)
     }
-}
-
-// FIXME this is no longer true, and has become more like an equipment related function
-fn stat_at(stat_rate: f64, stat_start: i32, level: i32) -> i32 {
-    let stat_rate = stat_rate / ((level / 25 + 1 ) as f64);
-    let inc_rate = 1.0 + stat_rate;
-    (stat_start as f64 * inc_rate.powi(level)) as i32
 }
 
 // Enemy classes are grouped into near/mid/far groups
@@ -88,13 +92,18 @@ fn weighted_choice(distance: location::Distance) -> &'static Class {
 /// For when it's not obvious how a given class would differ from the resst.
 const BASE: Class = Class {
     name: "enemy",
-    start_hp: 20,
-    start_strength: 10,
-    start_speed: 3,
-
-    hp_rate: 0.10,
-    strength_rate: 0.07,
-    speed_rate: 0.07,
+    hp: Stat {
+        base: 20,
+        inc_rate: 0.10,
+    },
+    strength: Stat {
+        base: 10,
+        inc_rate: 0.07,
+    },
+    speed: Stat {
+        base: 3,
+        inc_rate: 0.07,
+    },
 };
 
 const RAT: Class = Class {

--- a/src/character/class.rs
+++ b/src/character/class.rs
@@ -33,9 +33,9 @@ pub struct Class {
 impl Class {
     pub const HERO: Self = Self {
         name: "hero",
-        hp: Stat(25, 7),
-        strength: Stat(10, 3),
-        speed: Stat(10, 2),
+        hp: Stat(30, 7),
+        strength: Stat(12, 3),
+        speed: Stat(11, 2),
     };
 
     pub fn random_enemy(distance: location::Distance) -> &'static Self {

--- a/src/character/class.rs
+++ b/src/character/class.rs
@@ -2,19 +2,20 @@ use crate::location;
 use rand::prelude::SliceRandom;
 
 #[derive(Debug)]
-struct Stat {
-    pub base: i32,
-    // TODO does it make sense to make this a rate, and make those calculations, if it's always going to be fixed?
-    pub inc_rate: f64,
-}
+pub struct Stat(i32, i32);
 
+/// FIXME
 impl Stat {
-    pub fn at(&self, level: i32) -> i32 {
-        self.base + level * self.increase()
+    pub fn base(&self) -> i32 {
+        self.0
     }
 
     pub fn increase(&self) -> i32 {
-        (self.base as f64 * self.inc_rate).ceil() as i32
+        self.1
+    }
+
+    pub fn at(&self, level: i32) -> i32 {
+        self.0 + level * self.increase()
     }
 }
 
@@ -32,18 +33,9 @@ pub struct Class {
 impl Class {
     pub const HERO: Self = Self {
         name: "hero",
-        hp: Stat {
-            base: 25,
-            inc_rate: 0.25,
-        },
-        strength: Stat {
-            base: 10,
-            inc_rate: 0.2,
-        },
-        speed: Stat {
-            base: 5,
-            inc_rate: 0.1,
-        },
+        hp: Stat(25, 7),
+        strength: Stat(10, 3),
+        speed: Stat(10, 2),
     };
 
     pub fn random_enemy(distance: location::Distance) -> &'static Self {
@@ -88,175 +80,121 @@ fn weighted_choice(distance: location::Distance) -> &'static Class {
 // 2. decreasing rates to prevent overgrowth at higher levels
 // as a starting measure, using increase rates way below those of the player
 
-/// Defaults for all enemies.
-/// For when it's not obvious how a given class would differ from the resst.
-const BASE: Class = Class {
-    name: "enemy",
-    hp: Stat {
-        base: 20,
-        inc_rate: 0.10,
-    },
-    strength: Stat {
-        base: 10,
-        inc_rate: 0.07,
-    },
-    speed: Stat {
-        base: 3,
-        inc_rate: 0.07,
-    },
-};
-
 const RAT: Class = Class {
     name: "rat",
-    start_hp: 10,
-    start_strength: 5,
-    start_speed: 8,
-
-    ..BASE
+    hp: Stat(10, 3),
+    strength: Stat(5, 2),
+    speed: Stat(16, 2),
 };
 
 const WOLF: Class = Class {
     name: "wolf",
-    start_hp: 15,
-    start_strength: 8,
-    start_speed: 6,
-
-    ..BASE
+    hp: Stat(15, 3),
+    strength: Stat(8, 2),
+    speed: Stat(12, 2),
 };
 
 const SNAKE: Class = Class {
     name: "snake",
-    start_hp: 13,
-    start_strength: 7,
-    start_speed: 3,
-
-    ..BASE
+    hp: Stat(13, 3),
+    strength: Stat(7, 2),
+    speed: Stat(6, 2),
 };
 
 const SLIME: Class = Class {
     name: "slime",
-    start_hp: 100,
-    start_strength: 3,
-    start_speed: 2,
-
-    ..BASE
+    hp: Stat(80, 3),
+    strength: Stat(3, 2),
+    speed: Stat(4, 2),
 };
 
 const SPIDER: Class = Class {
     name: "spider",
-    start_hp: 10,
-    start_strength: 9,
-    start_speed: 6,
-
-    ..BASE
+    hp: Stat(10, 3),
+    strength: Stat(9, 2),
+    speed: Stat(12, 2),
 };
 
 const ZOMBIE: Class = Class {
     name: "zombie",
-    start_hp: 50,
-    start_strength: 8,
-    start_speed: 3,
-
-    ..BASE
+    hp: Stat(50, 3),
+    strength: Stat(8, 2),
+    speed: Stat(6, 2),
 };
 
 const ORC: Class = Class {
     name: "orc",
-    start_hp: 35,
-    start_strength: 13,
-    start_speed: 6,
-
-    ..BASE
+    hp: Stat(35, 3),
+    strength: Stat(13, 2),
+    speed: Stat(12, 2),
 };
 
 const SKELETON: Class = Class {
     name: "skeleton",
-    start_hp: 30,
-    start_strength: 10,
-    start_speed: 5,
-
-    ..BASE
+    hp: Stat(30, 3),
+    strength: Stat(10, 2),
+    speed: Stat(10, 2),
 };
 
 const DEMON: Class = Class {
     name: "demon",
-    start_hp: 50,
-    start_strength: 10,
-    start_speed: 9,
-
-    ..BASE
+    hp: Stat(50, 3),
+    strength: Stat(10, 2),
+    speed: Stat(18, 2),
 };
 
 const VAMPIRE: Class = Class {
     name: "vampire",
-    start_hp: 50,
-    start_strength: 13,
-    start_speed: 5,
-
-    ..BASE
+    hp: Stat(50, 3),
+    strength: Stat(13, 2),
+    speed: Stat(10, 2),
 };
 
 const DRAGON: Class = Class {
     name: "dragon",
-    start_hp: 100,
-    start_strength: 25,
-    start_speed: 4,
-
-    ..BASE
+    hp: Stat(100, 3),
+    strength: Stat(25, 2),
+    speed: Stat(8, 2),
 };
 
 const GOLEM: Class = Class {
     name: "golem",
-    start_hp: 50,
-    start_strength: 45,
-    start_speed: 1,
-
-    speed_rate: 0.04,
-
-    ..BASE
+    hp: Stat(50, 3),
+    strength: Stat(45, 2),
+    speed: Stat(2, 1),
 };
 
 const CHIMERA: Class = Class {
     name: "chimera",
-    start_hp: 200,
-    start_strength: 90,
-    start_speed: 8,
-
-    ..BASE
+    hp: Stat(200, 2),
+    strength: Stat(90, 2),
+    speed: Stat(16, 2),
 };
 
 const BASILISK: Class = Class {
     name: "basilisk",
-    start_hp: 150,
-    start_strength: 100,
-    start_speed: 9,
-
-    ..BASE
+    hp: Stat(150, 3),
+    strength: Stat(100, 2),
+    speed: Stat(18, 2),
 };
 
 const MINOTAUR: Class = Class {
     name: "minotaur",
-    start_hp: 100,
-    start_strength: 60,
-    start_speed: 20,
-
-    ..BASE
+    hp: Stat(100, 3),
+    strength: Stat(60, 2),
+    speed: Stat(40, 2),
 };
 
 const BALROG: Class = Class {
     name: "balrog",
-    start_hp: 200,
-    start_strength: 200,
-    start_speed: 7,
-
-    ..BASE
+    hp: Stat(200, 3),
+    strength: Stat(200, 2),
+    speed: Stat(14, 2),
 };
 
 const PHOENIX: Class = Class {
     name: "phoenix",
-    start_hp: 350,
-    start_strength: 180,
-    start_speed: 14,
-
-    ..BASE
+    hp: Stat(350, 3),
+    strength: Stat(180, 2),
+    speed: Stat(28, 2),
 };

--- a/src/character/class.rs
+++ b/src/character/class.rs
@@ -2,7 +2,7 @@ use crate::location;
 use rand::prelude::SliceRandom;
 
 #[derive(Debug)]
-pub struct Stat(i32, i32);
+pub struct Stat(pub i32, pub i32);
 
 /// FIXME
 impl Stat {

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -8,10 +8,6 @@ pub mod class;
 use crate::randomizer::{random, Randomizer};
 use class::Class;
 
-/// If we let the stats grow indefinitely they would eventually overflow
-/// 500 levels seems a reasonable ceiling
-const MAX_LEVEL: i32 = 500;
-
 #[derive(Serialize, Deserialize, Debug)]
 pub struct Character {
     #[serde(skip, default = "default_class")]
@@ -61,10 +57,10 @@ impl Character {
             xp: 0,
 
             // TODO these could be randomized from the start
-            max_hp: class.hp.base,
-            current_hp: class.hp.base,
-            strength: class.hp.base,
-            speed: class.speed.base,
+            max_hp: class.hp.base(),
+            current_hp: class.hp.base(),
+            strength: class.hp.base(),
+            speed: class.speed.base(),
         };
 
         for _ in 1..level {
@@ -78,18 +74,14 @@ impl Character {
     fn increase_level(&mut self) {
         self.level += 1;
 
-        // after this we increase the number but not the stats
-        if self.level < MAX_LEVEL {
-            self.strength =
-                random().stat_increase(self.class.strength.increase());
-            self.speed = random().stat_increase(self.class.speed.increase());
+        self.strength = random().stat_increase(self.class.strength.increase());
+        self.speed = random().stat_increase(self.class.speed.increase());
 
-            // the current should increase proportionally but not
-            // erase previous damage
-            let previous_damage = self.max_hp - self.current_hp;
-            self.max_hp = random().stat_increase(self.class.hp.increase());
-            self.current_hp = self.max_hp - previous_damage;
-        }
+        // the current should increase proportionally but not
+        // erase previous damage
+        let previous_damage = self.max_hp - self.current_hp;
+        self.max_hp = random().stat_increase(self.class.hp.increase());
+        self.current_hp = self.max_hp - previous_damage;
     }
 
     /// Add to the accumulated experience points, possibly increasing the level.
@@ -345,7 +337,7 @@ mod tests {
     fn test_overflow() {
         let mut hero = Character::player();
 
-        while hero.level < MAX_LEVEL {
+        while hero.level < 500 {
             hero.add_experience(hero.xp_for_next());
             hero.sword = Some(equipment::Sword::new(hero.level));
             let turns_unarmed = hero.max_hp / hero.strength;

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -55,11 +55,9 @@ impl Character {
             shield: None,
             level: 1,
             xp: 0,
-
-            // TODO these could be randomized from the start
             max_hp: class.hp.base(),
             current_hp: class.hp.base(),
-            strength: class.hp.base(),
+            strength: class.strength.base(),
             speed: class.speed.base(),
         };
 
@@ -74,13 +72,13 @@ impl Character {
     fn increase_level(&mut self) {
         self.level += 1;
 
-        self.strength = random().stat_increase(self.class.strength.increase());
-        self.speed = random().stat_increase(self.class.speed.increase());
+        self.strength += random().stat_increase(self.class.strength.increase());
+        self.speed += random().stat_increase(self.class.speed.increase());
 
         // the current should increase proportionally but not
         // erase previous damage
         let previous_damage = self.max_hp - self.current_hp;
-        self.max_hp = random().stat_increase(self.class.hp.increase());
+        self.max_hp += random().stat_increase(self.class.hp.increase());
         self.current_hp = self.max_hp - previous_damage;
     }
 
@@ -159,16 +157,13 @@ impl Character {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use class::Stat;
 
     const TEST_CLASS: Class = Class {
         name: "test",
-        start_hp: 25,
-        start_strength: 10,
-        start_speed: 5,
-
-        hp_rate: 0.3,
-        strength_rate: 0.1,
-        speed_rate: 0.1,
+        hp: Stat(25, 7),
+        strength: Stat(10, 3),
+        speed: Stat(10, 2),
     };
 
     fn new_char() -> Character {
@@ -182,10 +177,10 @@ mod tests {
         assert_eq!(1, hero.level);
         assert_eq!(0, hero.xp);
 
-        assert_eq!(TEST_CLASS.start_hp, hero.current_hp);
-        assert_eq!(TEST_CLASS.start_hp, hero.max_hp);
-        assert_eq!(TEST_CLASS.start_strength, hero.strength);
-        assert_eq!(TEST_CLASS.start_speed, hero.speed);
+        assert_eq!(TEST_CLASS.hp.base(), hero.current_hp);
+        assert_eq!(TEST_CLASS.hp.base(), hero.max_hp);
+        assert_eq!(TEST_CLASS.strength.base(), hero.strength);
+        assert_eq!(TEST_CLASS.speed.base(), hero.speed);
     }
 
     #[test]
@@ -193,9 +188,9 @@ mod tests {
         let mut hero = new_char();
 
         // assert what we're assuming are the params in the rest of the test
-        assert_eq!(0.3, TEST_CLASS.hp_rate);
-        assert_eq!(0.1, TEST_CLASS.strength_rate);
-        assert_eq!(0.1, TEST_CLASS.speed_rate);
+        assert_eq!(7, TEST_CLASS.hp.increase());
+        assert_eq!(3, TEST_CLASS.strength.increase());
+        assert_eq!(2, TEST_CLASS.speed.increase());
 
         hero.max_hp = 20;
         hero.current_hp = 20;
@@ -204,9 +199,9 @@ mod tests {
 
         hero.increase_level();
         assert_eq!(2, hero.level);
-        assert_eq!(26, hero.max_hp);
-        assert_eq!(11, hero.strength);
-        assert_eq!(6, hero.speed);
+        assert_eq!(27, hero.max_hp);
+        assert_eq!(13, hero.strength);
+        assert_eq!(7, hero.speed);
 
         let damage = 7;
         hero.current_hp -= damage;

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -329,4 +329,31 @@ mod tests {
         assert_eq!(25, hero.max_hp);
         assert_eq!(25, hero.current_hp);
     }
+
+    #[test]
+    fn test_overflow() {
+        let mut hero = new_char();
+
+        while hero.level < 200 {
+            hero.add_experience(hero.xp_for_next());
+            hero.sword = Some(equipment::Sword::new(hero.level));
+            let turns_unarmed = hero.max_hp / hero.strength;
+            let turns_armed = hero.max_hp / hero.attack();
+            println!(
+                "hero[{}] next={} hp={} spd={} str={} att={} turns_u={} turns_a={}",
+                hero.level,
+                hero.xp_for_next(),
+                hero.max_hp,
+                hero.speed,
+                hero.strength,
+                hero.attack(),
+                turns_unarmed,
+                turns_armed
+            );
+
+            assert!(hero.max_hp > 0);
+            assert!(hero.speed > 0);
+            assert!(hero.attack() > 0);
+        }
+    }
 }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -352,6 +352,9 @@ mod tests {
             assert!(hero.max_hp > 0);
             assert!(hero.speed > 0);
             assert!(hero.attack() > 0);
+
+            assert!(turns_armed < turns_unarmed);
+            assert!(turns_armed < 20);
         }
         // assert!(false);
     }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -59,10 +59,12 @@ impl Character {
             shield: None,
             level: 1,
             xp: 0,
-            max_hp: class.start_hp,
-            current_hp: class.start_hp,
-            strength: class.start_strength,
-            speed: class.start_speed,
+
+            // TODO these could be randomized from the start
+            max_hp: class.hp.base,
+            current_hp: class.hp.base,
+            strength: class.hp.base,
+            speed: class.speed.base,
         };
 
         for _ in 1..level {
@@ -78,13 +80,14 @@ impl Character {
 
         // after this we increase the number but not the stats
         if self.level < MAX_LEVEL {
-            self.strength = random().stat_increase(self.level, self.strength, self.class.strength_rate);
-            self.speed = random().stat_increase(self.level, self.speed, self.class.speed_rate);
+            self.strength =
+                random().stat_increase(self.class.strength.increase());
+            self.speed = random().stat_increase(self.class.speed.increase());
 
             // the current should increase proportionally but not
             // erase previous damage
             let previous_damage = self.max_hp - self.current_hp;
-            self.max_hp = random().stat_increase(self.level, self.max_hp, self.class.hp_rate);
+            self.max_hp = random().stat_increase(self.class.hp.increase());
             self.current_hp = self.max_hp - previous_damage;
         }
     }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -71,13 +71,13 @@ impl Character {
     /// Raise the level and all the character stats.
     fn increase_level(&mut self) {
         self.level += 1;
-        self.strength = random().stat_increase(self.strength, self.class.strength_rate);
-        self.speed = random().stat_increase(self.speed, self.class.speed_rate);
+        self.strength = random().stat_increase(self.level, self.strength, self.class.strength_rate);
+        self.speed = random().stat_increase(self.level, self.speed, self.class.speed_rate);
 
         // the current should increase proportionally but not
         // erase previous damage
         let previous_damage = self.max_hp - self.current_hp;
-        self.max_hp = random().stat_increase(self.max_hp, self.class.hp_rate);
+        self.max_hp = random().stat_increase(self.level, self.max_hp, self.class.hp_rate);
         self.current_hp = self.max_hp - previous_damage;
     }
 
@@ -124,7 +124,7 @@ impl Character {
         (base_xp * (self.level as f64).powf(exp)) as i32
     }
 
-    /// Generate a randomized damage numer based on the attacker strength
+    /// Generate a randomized damage number based on the attacker strength
     /// and the receiver strength.
     pub fn damage(&self, receiver: &Self) -> i32 {
         max(1, self.attack() - receiver.deffense())
@@ -332,7 +332,7 @@ mod tests {
 
     #[test]
     fn test_overflow() {
-        let mut hero = new_char();
+        let mut hero = Character::player();
 
         while hero.level < 200 {
             hero.add_experience(hero.xp_for_next());
@@ -355,5 +355,6 @@ mod tests {
             assert!(hero.speed > 0);
             assert!(hero.attack() > 0);
         }
+        // assert!(false);
     }
 }

--- a/src/game/battle.rs
+++ b/src/game/battle.rs
@@ -124,7 +124,7 @@ mod tests {
         assert_eq!(15, game.player.current_hp);
         assert_eq!(1, game.player.level);
         assert_eq!(20, game.player.xp);
-        assert_eq!(100, game.gold);
+        assert_eq!(50, game.gold);
 
         let mut enemy = Character::enemy(1, Distance::Near(1));
         enemy.speed = 1;
@@ -137,7 +137,7 @@ mod tests {
         assert!(result.is_ok());
         assert_eq!(2, game.player.level);
         assert_eq!(10, game.player.xp);
-        assert_eq!(200, game.gold);
+        assert_eq!(100, game.gold);
     }
 
     #[test]

--- a/src/game/battle.rs
+++ b/src/game/battle.rs
@@ -56,7 +56,11 @@ fn enemy_attack(game: &mut Game, enemy: &Character, random: &dyn Randomizer) {
 
 /// Inflict damage from attacker to receiver, return the inflicted
 /// damage and the experience that will be gain if the battle is won
-fn attack(attacker: &Character, receiver: &mut Character, random: &dyn Randomizer) -> (Attack, i32) {
+fn attack(
+    attacker: &Character,
+    receiver: &mut Character,
+    random: &dyn Randomizer,
+) -> (Attack, i32) {
     if random.is_miss(attacker.speed, receiver.speed) {
         (Attack::Miss, 0)
     } else {

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -218,7 +218,7 @@ fn enemy_level(player_level: i32, distance_from_home: i32) -> i32 {
 
 fn gold_gained(player_level: i32, enemy_level: i32) -> i32 {
     let level = std::cmp::max(1, enemy_level - player_level);
-    random().gold_gained(level * 100)
+    random().gold_gained(level * 50)
 }
 
 #[cfg(test)]

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -217,7 +217,7 @@ fn enemy_level(player_level: i32, distance_from_home: i32) -> i32 {
 }
 
 fn gold_gained(player_level: i32, enemy_level: i32) -> i32 {
-    let level =  std::cmp::max(1, enemy_level - player_level);
+    let level = std::cmp::max(1, enemy_level - player_level);
     random().gold_gained(level * 100)
 }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -159,7 +159,7 @@ impl Game {
     }
 
     fn bribe(&mut self, enemy: &Character) -> bool {
-        let bribe_cost = gold_gained(enemy.level) / 2;
+        let bribe_cost = gold_gained(self.player.level, enemy.level) / 2;
 
         if self.gold >= bribe_cost && random().bribe_succeeds() {
             self.gold -= bribe_cost;
@@ -181,7 +181,7 @@ impl Game {
 
     fn battle(&mut self, enemy: &mut Character) -> Result<(), Error> {
         if let Ok(xp) = battle::run(self, enemy, &random()) {
-            let gold = gold_gained(enemy.level);
+            let gold = gold_gained(self.player.level, enemy.level);
             self.gold += gold;
             let level_up = self.player.add_experience(xp);
 
@@ -216,8 +216,9 @@ fn enemy_level(player_level: i32, distance_from_home: i32) -> i32 {
     std::cmp::max(player_level / 2 + distance_from_home - 1, 1)
 }
 
-fn gold_gained(enemy_level: i32) -> i32 {
-    random().gold_gained(enemy_level * 100)
+fn gold_gained(player_level: i32, enemy_level: i32) -> i32 {
+   let level =  std::cmp::max(2, enemy_level - player_level);
+    random().gold_gained(level * 100)
 }
 
 #[cfg(test)]

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -292,22 +292,22 @@ mod tests {
         // level's equipment, should be able to beat any enemy of its same level
         // without relying in randomness.
         let (wins, lost_to) = run_battles_at(1, 1, times);
-        assert_wins(times, wins, 0.75, &lost_to);
+        assert_wins(times, wins, 0.7, &lost_to);
 
         let (wins, lost_to) = run_battles_at(1, 3, times);
         assert_wins(times, wins, 0.3, &lost_to);
 
         let (wins, lost_to) = run_battles_at(5, 5, times);
-        assert_wins(times, wins, 0.75, &lost_to);
+        assert_wins(times, wins, 0.7, &lost_to);
 
         let (wins, lost_to) = run_battles_at(10, 5, times);
-        assert_wins(times, wins, 0.75, &lost_to);
+        assert_wins(times, wins, 0.7, &lost_to);
 
         let (wins, lost_to) = run_battles_at(10, 10, times);
         assert_wins(times, wins, 0.4, &lost_to);
 
         let (wins, lost_to) = run_battles_at(15, 13, times);
-        assert_wins(times, wins, 0.75, &lost_to);
+        assert_wins(times, wins, 0.7, &lost_to);
 
         let (wins, lost_to) = run_battles_at(15, 15, times);
         assert_wins(times, wins, 0.5, &lost_to);

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -293,7 +293,7 @@ mod tests {
         // level's equipment, should be able to beat any enemy of its same level
         // without relying in randomness.
         let (wins, lost_to) = run_battles_at(1, 1, times);
-        assert_wins(times, wins, 0.7, &lost_to);
+        assert_wins(times, wins, 0.5, &lost_to);
 
         let (wins, lost_to) = run_battles_at(1, 3, times);
         assert_wins(times, wins, 0.3, &lost_to);
@@ -313,6 +313,12 @@ mod tests {
         let (wins, lost_to) = run_battles_at(15, 15, times);
         assert_wins(times, wins, 0.5, &lost_to);
 
+        let (wins, lost_to) = run_battles_at(50, 50, times);
+        assert_wins(times, wins, 0.4, &lost_to);
+
+        let (wins, lost_to) = run_battles_at(100, 100, times);
+        assert_wins(times, wins, 0.4, &lost_to);
+
         // it shouldn't be too easy either --stronger enemies should have
         // chances of winning (even with all the equipment)
         let (wins, _) = run_battles_at(1, 6, times);
@@ -331,6 +337,12 @@ mod tests {
         assert_loses(times, wins, 0.15);
 
         let (wins, _) = run_battles_at(15, 20, times);
+        assert_loses(times, wins, 0.15);
+
+        let (wins, _) = run_battles_at(15, 20, times);
+        assert_loses(times, wins, 0.15);
+
+        let (wins, _) = run_battles_at(50, 60, times);
         assert_loses(times, wins, 0.15);
     }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -217,7 +217,7 @@ fn enemy_level(player_level: i32, distance_from_home: i32) -> i32 {
 }
 
 fn gold_gained(player_level: i32, enemy_level: i32) -> i32 {
-   let level =  std::cmp::max(2, enemy_level - player_level);
+    let level =  std::cmp::max(1, enemy_level - player_level);
     random().gold_gained(level * 100)
 }
 

--- a/src/game/mod.rs
+++ b/src/game/mod.rs
@@ -222,8 +222,8 @@ fn gold_gained(enemy_level: i32) -> i32 {
 
 #[cfg(test)]
 mod tests {
-    use item::equipment::Equipment;
     use crate::location::Distance;
+    use item::equipment::Equipment;
 
     use super::*;
     use crate::item;
@@ -334,12 +334,24 @@ mod tests {
     }
 
     fn assert_wins(total: i32, wins: i32, expected_ratio: f64, lost_to: &Vec<String>) {
-        assert!(wins as f64 >= total as f64 * expected_ratio , "won {} out of {}. Lost to {:?}", wins, total, lost_to);
+        assert!(
+            wins as f64 >= total as f64 * expected_ratio,
+            "won {} out of {}. Lost to {:?}",
+            wins,
+            total,
+            lost_to
+        );
     }
 
     fn assert_loses(total: i32, wins: i32, expected_ratio: f64) {
         let expected = (total as f64) * (1.0 - expected_ratio);
-        assert!((wins as f64) <= expected, "won {} out of {} expected at most {}", wins, total, expected);
+        assert!(
+            (wins as f64) <= expected,
+            "won {} out of {} expected at most {}",
+            wins,
+            total,
+            expected
+        );
     }
 
     fn run_battles_at(player_level: i32, distance: i32, times: i32) -> (i32, Vec<String>) {
@@ -347,7 +359,7 @@ mod tests {
         let mut lost_to = Vec::new();
 
         // we don't want randomization turned off for this test
-        let random = randomizer::DefaultRandomizer{};
+        let random = randomizer::DefaultRandomizer {};
 
         for _ in 0..times {
             let mut game = full_game_at(player_level);
@@ -371,7 +383,7 @@ mod tests {
         let mut game = Game::new();
 
         // get a player of the given level
-        for _ in 0..level-1 {
+        for _ in 0..level - 1 {
             game.player.add_experience(game.player.xp_for_next());
         }
         assert_eq!(level, game.player.level);

--- a/src/item/equipment.rs
+++ b/src/item/equipment.rs
@@ -12,7 +12,7 @@ pub trait Equipment: fmt::Display {
     /// the item is equipped.
     fn strength(&self) -> i32 {
         // get the base strength of the hero at this level
-        let player_strength = character::Class::HERO.strength_at(self.level());
+        let player_strength = character::Class::HERO.strength.at(self.level());
 
         // calculate the added strength as a function of the player strength
         (player_strength as f64 * 0.5).round() as i32

--- a/src/item/mod.rs
+++ b/src/item/mod.rs
@@ -33,7 +33,7 @@ impl fmt::Display for Potion {
 #[typetag::serde]
 impl Item for Potion {
     fn apply(&self, game: &mut game::Game) {
-        let to_restore = character::Class::HERO.hp_at(self.level) / 2;
+        let to_restore = character::Class::HERO.hp.at(self.level) / 2;
         let restored = game.player.heal(to_restore);
 
         // we prefer the battle here since its less ugly to show battle-like

--- a/src/randomizer.rs
+++ b/src/randomizer.rs
@@ -106,7 +106,7 @@ impl Randomizer for DefaultRandomizer {
 
     fn stat_increase(&self, increase: i32) -> i32 {
         let min_value = max(1, increase / 2);
-        let max_value = 3 * increase * 2;
+        let max_value = 3 * increase / 2;
 
         let mut rng = rand::thread_rng();
         rng.gen_range(min_value..=max_value)
@@ -163,28 +163,16 @@ mod tests {
     fn test_increase_stat() {
         let rand = DefaultRandomizer {};
 
-        // current hp lvl1: increase in .3 +/- .15
-        let value = rand.stat_increase(1, 20, 0.3);
-        assert!((23..=29).contains(&value), "value was {}", value);
+        // current hp lvl1
+        let value = rand.stat_increase(7);
+        assert!((4..=10).contains(&value), "value was {}", value);
 
         // current strength lvl1
-        let value = rand.stat_increase(1, 10, 0.1);
-        assert!((11..=12).contains(&value), "value was {}", value);
+        let value = rand.stat_increase(3);
+        assert!((2..=4).contains(&value), "value was {}", value);
 
         // current speed lvl1
-        let value = rand.stat_increase(1, 5, 0.1);
-        assert_eq!(6, value);
-
-        // ~ hp lvl2
-        let value = rand.stat_increase(1, 26, 0.3);
-        assert!((30..=38).contains(&value), "value was {}", value);
-
-        // ~ hp lvl3
-        let value = rand.stat_increase(1, 34, 0.3);
-        assert!((39..=49).contains(&value), "value was {}", value);
-
-        // small numbers
-        let value = rand.stat_increase(1, 3, 0.07);
-        assert_eq!(4, value);
+        let value = rand.stat_increase(2);
+        assert!((1..=3).contains(&value), "value was {}", value);
     }
 }

--- a/src/randomizer.rs
+++ b/src/randomizer.rs
@@ -25,7 +25,7 @@ pub trait Randomizer {
 
     fn gold_gained(&self, base: i32) -> i32;
 
-    fn stat_increase(&self, level: i32, current: i32, rate: f64) -> i32;
+    fn stat_increase(&self, increase: i32) -> i32;
 }
 
 #[cfg(not(test))]
@@ -104,16 +104,12 @@ impl Randomizer for DefaultRandomizer {
         rng.gen_range(min..=max)
     }
 
-    fn stat_increase(&self, level: i32, current: i32, rate: f64) -> i32 {
-        let rate = rate / ((level / 10 + 1 ) as f64);
-
-        // if rate is .3, increase can be in .15-.45
-        let current_f = current as f64;
-        let min_value = max(1, (current_f * (rate - rate / 2.0)).round() as i32);
-        let max_value = max(1, (current_f * rate + rate / 2.0).round() as i32);
+    fn stat_increase(&self, increase: i32) -> i32 {
+        let min_value = max(1, increase / 2);
+        let max_value = 3 * increase * 2;
 
         let mut rng = rand::thread_rng();
-        current + rng.gen_range(min_value..=max_value)
+        rng.gen_range(min_value..=max_value)
     }
 }
 
@@ -154,9 +150,8 @@ impl Randomizer for TestRandomizer {
         base
     }
 
-    fn stat_increase(&self, level: i32, current: i32, rate: f64) -> i32 {
-        let rate = rate / ((level / 10 + 1 ) as f64);
-        current + (current as f64 * rate).ceil() as i32
+    fn stat_increase(&self, increase: i32) -> i32 {
+        increase
     }
 }
 

--- a/src/randomizer.rs
+++ b/src/randomizer.rs
@@ -165,14 +165,18 @@ mod tests {
 
         // current hp lvl1
         let value = rand.stat_increase(7);
-        assert!((4..=10).contains(&value), "value was {}", value);
+        assert!((3..=10).contains(&value), "value was {}", value);
 
         // current strength lvl1
         let value = rand.stat_increase(3);
-        assert!((2..=4).contains(&value), "value was {}", value);
+        assert!((1..=4).contains(&value), "value was {}", value);
 
         // current speed lvl1
         let value = rand.stat_increase(2);
         assert!((1..=3).contains(&value), "value was {}", value);
+
+        // small increase
+        let value = rand.stat_increase(1);
+        assert!((1..=2).contains(&value), "value was {}", value);
     }
 }

--- a/src/randomizer.rs
+++ b/src/randomizer.rs
@@ -25,7 +25,7 @@ pub trait Randomizer {
 
     fn gold_gained(&self, base: i32) -> i32;
 
-    fn stat_increase(&self, current: i32, rate: f64) -> i32;
+    fn stat_increase(&self, level: i32, current: i32, rate: f64) -> i32;
 }
 
 #[cfg(not(test))]
@@ -104,7 +104,9 @@ impl Randomizer for DefaultRandomizer {
         rng.gen_range(min..=max)
     }
 
-    fn stat_increase(&self, current: i32, rate: f64) -> i32 {
+    fn stat_increase(&self, level: i32, current: i32, rate: f64) -> i32 {
+        let rate = rate / ((level / 10 + 1 ) as f64);
+
         // if rate is .3, increase can be in .15-.45
         let current_f = current as f64;
         let min_value = max(1, (current_f * (rate - rate / 2.0)).round() as i32);
@@ -152,7 +154,8 @@ impl Randomizer for TestRandomizer {
         base
     }
 
-    fn stat_increase(&self, current: i32, rate: f64) -> i32 {
+    fn stat_increase(&self, level: i32, current: i32, rate: f64) -> i32 {
+        let rate = rate / ((level / 10 + 1 ) as f64);
         current + (current as f64 * rate).ceil() as i32
     }
 }
@@ -166,27 +169,27 @@ mod tests {
         let rand = DefaultRandomizer {};
 
         // current hp lvl1: increase in .3 +/- .15
-        let value = rand.stat_increase(20, 0.3);
+        let value = rand.stat_increase(1, 20, 0.3);
         assert!((23..=29).contains(&value), "value was {}", value);
 
         // current strength lvl1
-        let value = rand.stat_increase(10, 0.1);
+        let value = rand.stat_increase(1, 10, 0.1);
         assert!((11..=12).contains(&value), "value was {}", value);
 
         // current speed lvl1
-        let value = rand.stat_increase(5, 0.1);
+        let value = rand.stat_increase(1, 5, 0.1);
         assert_eq!(6, value);
 
         // ~ hp lvl2
-        let value = rand.stat_increase(26, 0.3);
+        let value = rand.stat_increase(1, 26, 0.3);
         assert!((30..=38).contains(&value), "value was {}", value);
 
         // ~ hp lvl3
-        let value = rand.stat_increase(34, 0.3);
+        let value = rand.stat_increase(1, 34, 0.3);
         assert!((39..=49).contains(&value), "value was {}", value);
 
         // small numbers
-        let value = rand.stat_increase(3, 0.07);
+        let value = rand.stat_increase(1, 3, 0.07);
         assert_eq!(4, value);
     }
 }


### PR DESCRIPTION
This introduces a Stat struct and makes the level increase stats by fixed (randomized) amounts instead of making them proportional to the current value, thus preventing them to grow too much.

Fixes #21 