### PR TITLE
Changed the "Use as a cd replacement" code snippet to prevent getting stopped at the directory the fight happens.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,8 @@ so the working directory is updated to track to the hero's progress. You can set
 
 ```sh
 rpg () {
-    rpg-cli "$@"
+    ABSPATH=$(realtpath $1)
+    rpg-cli $ABSPATH "${@:2}"
     cd "$(rpg-cli --pwd)"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -37,6 +37,15 @@ so the working directory is updated to track to the hero's progress. You can set
 
 ```sh
 rpg () {
+    rpg-cli "$@"
+    cd "$(rpg-cli --pwd)"
+}
+```
+
+The previous snippet won't continue to go into subdirectories if a fight happens in a directory. The next example will take you to the desired directory but with the obvious tradeoff that you won't be able to decide on your next steps after a battle.
+
+```sh
+rpg () {
     ABSPATH=$(realtpath $1)
     rpg-cli $ABSPATH "${@:2}"
     cd "$(rpg-cli --pwd)"


### PR DESCRIPTION
Whenever I used rpg on a long path, I would end up in the directory where the fight happened even if I actually wanted to go to a subdirectory of that directory. [Here is an example of what I mean.](https://asciinema.org/a/417782)

I changed the snippet in the README to prevent that. I am using ```realpath``` to do this, it should be installed per default on all *nix systems.

[This is how it looks now](https://asciinema.org/a/417781), as you can see I end up in folder5 even though I fought a battle on the way there.

As I am not experienced with fish so I wasn't able to make this change there.