### PR TITLE
Handle dead outside battle

### DIFF
--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -34,6 +34,8 @@ pub enum StatusEffect {
     Poisoned,
 }
 
+pub struct Dead;
+
 impl Default for Character {
     fn default() -> Self {
         Character::player()
@@ -113,8 +115,15 @@ impl Character {
         increased_levels
     }
 
-    pub fn receive_damage(&mut self, damage: i32) {
+    pub fn receive_damage(&mut self, damage: i32) -> Result<(), Dead> {
         self.current_hp = max(0, self.current_hp - damage);
+        if damage > self.current_hp {
+            self.current_hp = 0;
+            Err(Dead)
+        } else {
+            self.current_hp -= damage;
+            Ok(())
+        }
     }
 
     pub fn is_dead(&self) -> bool {
@@ -191,17 +200,17 @@ impl Character {
     }
 
     /// If the character suffers from a damage-producing status effect, apply it.
-    pub fn receive_status_effect_damage(&mut self) {
+    pub fn receive_status_effect_damage(&mut self) -> Result<(), Dead> {
         // NOTE: in the future we could have a positive status that e.g. regen hp
         match self.status_effect {
             Some(StatusEffect::Burning) | Some(StatusEffect::Poisoned) => {
                 let damage = std::cmp::max(1, self.max_hp / 20);
                 let damage = random().damage(damage);
-                // FIXME handle dead
-                self.receive_damage(damage);
                 event::status_effect_damage(self, damage);
+                self.receive_damage(damage)?;
+                Ok(())
             }
-            _ => (),
+            _ => Ok(()),
         }
     }
 }

--- a/src/character/mod.rs
+++ b/src/character/mod.rs
@@ -116,8 +116,7 @@ impl Character {
     }
 
     pub fn receive_damage(&mut self, damage: i32) -> Result<(), Dead> {
-        self.current_hp = max(0, self.current_hp - damage);
-        if damage > self.current_hp {
+        if damage >= self.current_hp {
             self.current_hp = 0;
             Err(Dead)
         } else {
@@ -426,19 +425,24 @@ mod tests {
         let mut hero = new_char();
         assert_eq!(25, hero.current_hp);
 
-        hero.receive_status_effect_damage();
+        hero.receive_status_effect_damage().unwrap_or_default();
         assert_eq!(25, hero.current_hp);
 
         hero.status_effect = Some(StatusEffect::Burning);
-        hero.receive_status_effect_damage();
+        hero.receive_status_effect_damage().unwrap_or_default();
         assert_eq!(24, hero.current_hp);
 
         hero.status_effect = Some(StatusEffect::Poisoned);
-        hero.receive_status_effect_damage();
+        hero.receive_status_effect_damage().unwrap_or_default();
         assert_eq!(23, hero.current_hp);
 
         hero.maybe_remove_status_effect();
-        hero.receive_status_effect_damage();
+        hero.receive_status_effect_damage().unwrap_or_default();
         assert_eq!(23, hero.current_hp);
+
+        hero.status_effect = Some(StatusEffect::Burning);
+        hero.current_hp = 1;
+        assert!(hero.receive_status_effect_damage().is_err());
+        assert!(hero.is_dead());
     }
 }

--- a/src/game/datafile.rs
+++ b/src/game/datafile.rs
@@ -1,7 +1,9 @@
 use std::{fs, io, path};
 
-pub fn read() -> io::Result<Vec<u8>> {
-    fs::read(file())
+pub struct NotFound;
+
+pub fn read() -> Result<Vec<u8>, NotFound> {
+    fs::read(file()).map_err(|_| NotFound)
 }
 
 pub fn write(data: Vec<u8>) -> Result<(), io::Error> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,7 +198,7 @@ fn shop(game: &mut Game, item_name: &Option<String>) {
 fn use_item(game: &mut Game, item_name: &Option<String>) {
     if let Some(item_name) = item_name {
         let item_name = sanitize(item_name);
-        if let Err(game::Error::ItemNotFound) = game.use_item(&item_name) {
+        if let Err(game::ItemNotFound) = game.use_item(&item_name) {
             println!("Item not found.");
         }
     } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,7 +147,7 @@ fn change_dir(game: &mut Game, dest: &str, run: bool, bribe: bool, force: bool) 
     if let Ok(dest) = Location::from(&dest) {
         if force {
             game.location = dest;
-        } else if let Err(game::Error::GameOver) = game.go_to(&dest, run, bribe) {
+        } else if let Err(character::Dead) = game.go_to(&dest, run, bribe) {
             game.reset();
             return 1;
         }
@@ -163,7 +163,7 @@ fn change_dir(game: &mut Game, dest: &str, run: bool, bribe: bool, force: bool) 
 fn battle(game: &mut Game, run: bool, bribe: bool) -> i32 {
     let mut exit_code = 0;
     if let Some(mut enemy) = game.maybe_spawn_enemy() {
-        if let Err(game::Error::GameOver) = game.maybe_battle(&mut enemy, run, bribe) {
+        if let Err(character::Dead) = game.maybe_battle(&mut enemy, run, bribe) {
             game.reset();
             exit_code = 1;
         }

--- a/src/randomizer.rs
+++ b/src/randomizer.rs
@@ -146,7 +146,7 @@ fn is_miss(attacker_speed: i32, receiver_speed: i32) -> bool {
 
 fn status_effect(produced_status: Option<StatusEffect>) -> Option<StatusEffect> {
     let mut rng = rand::thread_rng();
-    if rng.gen_ratio(1, 20){
+    if rng.gen_ratio(1, 20) {
         produced_status
     } else {
         None


### PR DESCRIPTION
Require to explicitly handle a character dead when inflicting damage.