### PR TITLE
Make buying in the shop an atomic operation

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -149,11 +149,8 @@ fn shop(game: &mut Game, items: &[String]) -> Result<()> {
     if items.is_empty() {
         item::shop::list(game)
     } else {
-        for item_name in items {
-            let item_name = sanitize(item_name);
-            item::shop::buy(game, &item_name)?
-        }
-        Ok(())
+        let items: Vec<_> = items.iter().map(|s| sanitize(s)).collect();
+        item::shop::buy(game, &items)
     }
 }
 


### PR DESCRIPTION
Hey,

While playing this fun game I found out that giving multiple items to the `buy` subcommand was just buying the items one after the other. I thought that it would be better for the player to be informed when the buy command can't buy **all** of the items instead. What do you think?

I wanted to implement it by cloning the `Game` struct and trying to buy all of the items with this "temporary game", outputting a nice message saying that the given shopping list can't be bought but the Game struct can't be cloned and that was tedious to make it so. I decided to implement it in another way.