### PR TITLE
Update fish shell example

### DIFF
--- a/shell/example.fish
+++ b/shell/example.fish
@@ -19,7 +19,7 @@ function cd
     if count $argv > /dev/null
         rpg-cli cd "$argv"
     else
-        rpg-cli cd $HOME 
+        rpg-cli cd $HOME
     end
     sync_rpg
 end
@@ -44,7 +44,9 @@ function dn
     if string match -r -q $regex $location
         set next_dir (math $location + 1)
         command mkdir -p $next_dir && cd $next_dir && rpg ls
+    else if string match -r -q '^dungeon$' $location
+        command mkdir -p 1 && cd 1 && rpg ls
     else
-        command mkdir -p dungeon/1 && cd dungeon/1 && rpg ls
+        command mkdir -p dungeon && rpg-cli cd dungeon && rpg ls
     end
 end

--- a/shell/example.fish
+++ b/shell/example.fish
@@ -15,19 +15,36 @@ end
 # - the one supplied as parameter, if there weren't any battles
 # - the one where the battle took place, if the hero wins
 # - the home dir, if the hero dies
-function cd_fn
-  rpg-cli cd "$argv"
-  sync_rpg
+function cd
+    if count $argv > /dev/null
+        rpg-cli cd "$argv"
+    else
+        rpg-cli cd $HOME 
+    end
+    sync_rpg
 end
 
 # Some directories have hidden treasure chests that you can find with ls
-function l_fn
-  command ls "$argv"
-  if test 'count $argv' > 0
-      rpg cd -f .
-      rpg ls
-  end
+function ls
+    if count $argv > /dev/null
+        rpg-cli cd -f $argv[1]
+        rpg-cli ls
+        command ls $argv[1]
+        rpg-cli cd -f (pwd)
+    else
+        rpg-cli ls
+        command ls
+    end
 end
 
-alias 'cd'='cd_fn'
-alias 'l'='l_fn'
+# Create dungeon
+function dn
+    set regex '^[0-9]+$'
+    set location (basename (pwd))
+    if string match -r -q $regex $location
+        set next_dir (math $location + 1)
+        command mkdir -p $next_dir && cd $next_dir && rpg ls
+    else
+        command mkdir -p dungeon/1 && cd dungeon/1 && rpg ls
+    end
+end


### PR DESCRIPTION
fix duplicate "dungeon" folder created by dn command if user is attacked before entering the "1" folder.