### PR TITLE
cd force flag now calls visit to reset character when cd'ing to home

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+### Fixed
+* `cd --force` now applies directory side effects (status effects and heal at home) #128
 
 ## [1.0.0](https://github.com/facundoolano/rpg-cli/releases/tag/1.0.0) - 2021-09-07
 ### Fixed

--- a/src/command.rs
+++ b/src/command.rs
@@ -115,7 +115,7 @@ fn change_dir(game: &mut Game, dest: &str, run: bool, bribe: bool, force: bool) 
     let result = if force {
         // When change is force, skip enemies along the way
         // but still apply side-effects at destination
-        game.visit(&dest)
+        game.visit(dest)
     } else {
         game.go_to(&dest, run, bribe)
     };

--- a/src/command.rs
+++ b/src/command.rs
@@ -112,9 +112,8 @@ pub fn run(cmd: Option<Command>, game: &mut Game) -> Result<()> {
 /// in combat along the way.
 fn change_dir(game: &mut Game, dest: &str, run: bool, bribe: bool, force: bool) -> Result<()> {
     let dest = Location::from(dest)?;
-    if force {
-        game.location = dest;
-    } else if let Err(character::Dead) = game.go_to(&dest, run, bribe) {
+    if ( force &&  matches!(game.visit(dest.clone()), Err(character::Dead)) ) //If force, visit then check for dead
+        || ( matches!(game.go_to(&dest, run, bribe), Err(character::Dead) ) ) { //If not force, go_to and check for dead
         game.reset();
         bail!("");
     }

--- a/src/command.rs
+++ b/src/command.rs
@@ -322,7 +322,7 @@ mod tests {
 
         game.player.current_hp = 1;
 
-        // back home (without forcing)
+        // force back home should restore hp
         let cmd = Command::ChangeDir {
             destination: "~".to_string(),
             run: false,

--- a/src/command.rs
+++ b/src/command.rs
@@ -123,8 +123,8 @@ fn change_dir(game: &mut Game, dest: &str, run: bool, bribe: bool, force: bool) 
     if let Err(character::Dead) = result {
         game.reset();
         bail!("");
-    }   
-    
+    }
+
     Ok(())
 }
 

--- a/src/command.rs
+++ b/src/command.rs
@@ -303,6 +303,40 @@ mod tests {
     }
 
     #[test]
+    fn change_dir_home_force() {
+        let mut game = Game::new();
+
+        assert!(game.location.is_home());
+
+        // force move to a non home location
+        let cmd = Command::ChangeDir {
+            destination: "~/..".to_string(),
+            run: false,
+            bribe: false,
+            force: true,
+        };
+
+        let result = run(Some(cmd), &mut game);
+        assert!(result.is_ok());
+        assert!(!game.location.is_home());
+
+        game.player.current_hp = 1;
+
+        // back home (without forcing)
+        let cmd = Command::ChangeDir {
+            destination: "~".to_string(),
+            run: false,
+            bribe: false,
+            force: true,
+        };
+
+        let result = run(Some(cmd), &mut game);
+        assert!(result.is_ok());
+        assert!(game.location.is_home());
+        assert_eq!(game.player.max_hp(), game.player.current_hp);
+    }
+
+    #[test]
     fn inspect_tombstone() {
         // die at non home with some gold
         let mut game = Game::new();

--- a/src/command.rs
+++ b/src/command.rs
@@ -112,11 +112,19 @@ pub fn run(cmd: Option<Command>, game: &mut Game) -> Result<()> {
 /// in combat along the way.
 fn change_dir(game: &mut Game, dest: &str, run: bool, bribe: bool, force: bool) -> Result<()> {
     let dest = Location::from(dest)?;
-    if ( force &&  matches!(game.visit(dest.clone()), Err(character::Dead)) ) //If force, visit then check for dead
-        || ( matches!(game.go_to(&dest, run, bribe), Err(character::Dead) ) ) { //If not force, go_to and check for dead
+    let result = if force {
+        // When change is force, skip enemies along the way
+        // but still apply side-effects at destination
+        game.visit(&dest)
+    } else {
+        game.go_to(&dest, run, bribe)
+    };
+
+    if let Err(character::Dead) = result {
         game.reset();
         bail!("");
-    }
+    }   
+    
     Ok(())
 }
 


### PR DESCRIPTION
This pull request resolves #123, by instead of hard coding the changing of the location in `change_dir()`, offloading this to the `visit()` method in `game.rs`. 