### PR TITLE
Align clap to same version as in the .lock file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ bincode = "1.3.3"
 dirs = "3.0"
 rand = { version = "0.8.3", features = ["alloc"] }
 colored = "2"
-clap = "3.0.0-beta.2"
+clap = "3.0.0-beta.4"
 typetag = "0.1"
 dunce = "1.0.1"
 once_cell = "1.7.2"


### PR DESCRIPTION
I went to build this on OpenBSD and the `cargo` command in the README.md failed. I updated this `clap` from .2 to .4 (to agree with [what is in the .lock file](https://github.com/facundoolano/rpg-cli/blob/main/Cargo.lock#L51) ) and the build now works on my amd64 OpenBSD 7.0 machine.