### PR TITLE
Updated shell README.md examples.

### DIFF
--- a/shell/README.md
+++ b/shell/README.md
@@ -48,8 +48,8 @@ It can be integrated to the regular ls like this:
 ls () {
     command ls "$@"
     if [ $# -eq 0 ] ; then
-        rpg cd -f .
-        rpg ls
+        rpg-cli cd -f .
+        rpg-cli ls
     fi
 }
 ```


### PR DESCRIPTION
Changed the README in the shell folder so that the `ls` override uses `rpg-cli` instead of `rpg`